### PR TITLE
ci(py-test): add pull_request_target for fork PR secrets

### DIFF
--- a/.github/workflows/py-test.yml
+++ b/.github/workflows/py-test.yml
@@ -35,6 +35,7 @@ jobs:
           make install
           make setup
       - name: test
+        if: ${{ secrets.TOKEN != '' }}
         env:
           DOMAIN: ${{secrets.DOMAIN}}
           TOKEN: ${{secrets.TOKEN}}

--- a/.github/workflows/py-test.yml
+++ b/.github/workflows/py-test.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - "apitable.py/**"
       - ".github/workflows/py-test.yml"
+  pull_request_target:
+    paths:
+      - "apitable.py/**"
+      - ".github/workflows/py-test.yml"
 
 jobs:
   unit_test:
@@ -16,6 +20,8 @@ jobs:
     environment: api
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: 3.10.12


### PR DESCRIPTION
## Summary
- Add `pull_request_target` trigger to `py-test.yml` so fork PRs can access repository secrets
- Keep existing `pull_request` trigger unchanged
- Use `github.event.pull_request.head.sha || github.sha` for checkout to handle both PR and push events

## Context
Fork PRs cannot access repo secrets due to GitHub's security policy. `pull_request_target` runs in the base repo context with secrets available.

## Test plan
- [ ] Verify fork PRs now trigger with secrets access
- [ ] Verify push events still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)