### PR TITLE
fix: bump to 1.5.0 and use trusted publisher for PyPI

### DIFF
--- a/.github/workflows/py-deploy.yml
+++ b/.github/workflows/py-deploy.yml
@@ -2,28 +2,30 @@ name: Python Publish Package
 
 on:
   push:
-    paths: "apitable.py/pyproject.toml"
     tags:
       - "apitable.py@*"
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10.12
+          python-version: "3.10"
       - name: Python Poetry
         uses: abatilo/actions-poetry@v2
         with:
-          working-directory: ./apitable.py
           poetry-version: 1.5.1
-      - name: Build and publish
-        env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      - name: Build
         run: |
           cd apitable.py
-          make install
-          poetry publish --username=$PYPI_USERNAME --password=$PYPI_PASSWORD --build
+          poetry lock --no-update
+          poetry install
+          poetry build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: apitable.py/dist/

--- a/apitable.py/poetry.lock
+++ b/apitable.py/poetry.lock
@@ -503,4 +503,4 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "5981b4792652671b4893d7d2d38f706a295e32a8da8db2015e191182c86b05fd"
+content-hash = "d69624d8131f20d3acdb29cfc85e20ee348da2a3495384db7894cc65a40dd2fd"

--- a/apitable.py/pyproject.toml
+++ b/apitable.py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apitable"
-version = "1.4.2"
+version = "1.5.0"
 description = "APITable OpenAPI Python SDK"
 authors = ["APITable Ltd. <dev@apitable.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump version from 1.4.2 to 1.5.0
- Switch PyPI publish from username/password to OIDC trusted publisher (`pypa/gh-action-pypi-publish`)
- Fix poetry.lock inconsistency

## Context
Previous deploy failed with `403: User 'apitable' does not have a verified primary email address`. Trusted Publishers bypass this by using GitHub OIDC tokens instead.

## Before publishing
Need to configure Trusted Publisher on PyPI:
- Go to https://pypi.org/manage/project/apitable/settings/publishing/
- Add GitHub as publisher: repo `apitable/apitable-sdks`, workflow `py-deploy.yml`

## Test plan
- [ ] Configure trusted publisher on PyPI
- [ ] Merge this PR
- [ ] Tag `apitable.py@1.5.0` on develop to trigger publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)