### PR TITLE
fix(ci): auto-set PyPI version from tag

### DIFF
--- a/.github/workflows/py-deploy.yml
+++ b/.github/workflows/py-deploy.yml
@@ -2,7 +2,6 @@ name: Python Publish Package
 
 on:
   push:
-    paths: "apitable.py/pyproject.toml"
     tags:
       - "apitable.py@*"
 
@@ -13,17 +12,19 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10.12
+          python-version: "3.10"
       - name: Python Poetry
         uses: abatilo/actions-poetry@v2
         with:
-          working-directory: ./apitable.py
           poetry-version: 1.5.1
       - name: Build and publish
         env:
           PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
+          VERSION="${GITHUB_REF_NAME#apitable.py@}"
           cd apitable.py
-          make install
+          poetry version "$VERSION"
+          poetry lock --no-update
+          poetry install
           poetry publish --username=$PYPI_USERNAME --password=$PYPI_PASSWORD --build


### PR DESCRIPTION
## Summary
- Extract version from git tag name (e.g. `apitable.py@1.5.0` → `1.5.0`) via `poetry version` at build time
- No longer requires manual pyproject.toml version bumps before release
- Uses API token auth (PYPI_USERNAME/PYPI_PASSWORD secrets) instead of trusted publisher
- Removes stale `paths` trigger that doesn't apply to tag-based workflows

## Context
Previous publish failed because pyproject.toml was still at 1.4.2 while the tag was 1.5.0. This fix makes the version always match the tag automatically.

## Test plan
- [ ] Push tag `apitable.py@1.5.0` after merge to trigger publish
- [ ] Verify PyPI receives version 1.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)